### PR TITLE
Deprecating ::set-output

### DIFF
--- a/.github/workflows/fitbit.yml
+++ b/.github/workflows/fitbit.yml
@@ -29,7 +29,7 @@ jobs:
           FIREBASE_SA_BASE64: ${{ secrets.FIREBASE_SA_BASE64 }}
         run: |
           npx ts-node index.ts > count.tmp
-          echo "::set-output name=count::$(tail -n1 count.tmp)"
+          echo "count=$(tail -n1 count.tmp)" >> $GITHUB_OUTPUT
           rm ./count.tmp
 
       - name: update README


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/